### PR TITLE
Add `package-mode = false` to avoid error with poetry install

### DIFF
--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -6,6 +6,7 @@ authors = [
   "{{cookiecutter.author_name}} {{cookiecutter.author_email}}"
 ]
 readme = "README.md"
+package-mode = false
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.13"


### PR DESCRIPTION
This PR fixes a possibile error encountered with "poetry install"

* Adds `"package-mode = false"` to `pyproject.toml`